### PR TITLE
🐛 本番環境でAuth.jsセッションが認識されない問題を修正

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,9 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { getToken } from "next-auth/jwt";
 
 export async function proxy(request: NextRequest) {
+  const secure = process.env.NODE_ENV === "production";
   const token = await getToken({
     req: request,
     secret: process.env.AUTH_SECRET,
+    cookieName: secure
+      ? "__Secure-authjs.session-token"
+      : "authjs.session-token",
   });
 
   const { pathname } = request.nextUrl;


### PR DESCRIPTION
## Summary

- `getToken` のデフォルトクッキー名（`next-auth.session-token`）が next-auth v5 の実際のクッキー名（`authjs.session-token`）と異なるため、本番環境（HTTPS）でセッションが認識されずログイン後に `/auth` へリダイレクトされる問題を修正
- 本番: `__Secure-authjs.session-token`、開発: `authjs.session-token` を明示的に指定

## Test plan

- [ ] Vercel にデプロイ後、ログインして `/` に遷移できることを確認
- [ ] ローカルでも引き続きログイン・セッション維持が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)